### PR TITLE
Trash screen added

### DIFF
--- a/lib/screens/compose_email_screen.dart
+++ b/lib/screens/compose_email_screen.dart
@@ -91,7 +91,16 @@ class _ComposeEmailScreenState extends State<ComposeEmailScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Compose Email'),
+        title: const Text(
+          'COMPOSE EMAIL',
+          style: TextStyle(
+            fontSize: 50,
+            fontFamily: 'Itim',
+            color: Colors.red,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        centerTitle: true,
         actions: [
           IconButton(
             icon: const Icon(Icons.send),

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -115,7 +115,15 @@ class _ProfileScreenState extends State<ProfileScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Profile'),
+        title: const Text(
+          'PROFILE',
+          style: TextStyle(
+            fontSize: 50,
+            fontFamily: 'Itim',
+            color: Colors.red,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
         centerTitle: true,
       ),
       body: _isLoading

--- a/lib/screens/trash_screen.dart
+++ b/lib/screens/trash_screen.dart
@@ -1,0 +1,105 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import 'email_detail_screen.dart';
+
+class TrashScreen extends StatefulWidget {
+  const TrashScreen({super.key});
+
+  @override
+  State<TrashScreen> createState() => _TrashScreenState();
+}
+
+class _TrashScreenState extends State<TrashScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          'TRASH',
+          style: TextStyle(
+            fontSize: 50,
+            fontFamily: 'Itim',
+            color: Colors.red,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        centerTitle: true,
+      ),
+      body: StreamBuilder<QuerySnapshot>(
+        stream: FirebaseFirestore.instance
+            .collection('emails')
+            .where('isTrashed', isEqualTo: true)
+            .snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (!snapshot.hasData || snapshot.data!.docs.isEmpty) {
+            return const Center(
+              child: Opacity(
+                opacity: 0.5,
+                child: Text(
+                  'No emails in trash',
+                  style: TextStyle(
+                    fontSize: 50,
+                  ),
+                ),
+              ),
+            );
+          }
+
+          final trashedEmails = snapshot.data!.docs;
+
+          return ListView.builder(
+            itemCount: trashedEmails.length,
+            itemBuilder: (context, index) {
+              final email = trashedEmails[index].data() as Map<String, dynamic>;
+
+              return Card(
+                child: ListTile(
+                  title: Text(email['subject'] ?? 'No Subject'),
+                  subtitle: Text('From: ${email['from']}'),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.restore),
+                        onPressed: () {
+                          // Restore the email
+                          FirebaseFirestore.instance
+                              .collection('emails')
+                              .doc(email['id'])
+                              .update({'isTrashed': false});
+                        },
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.delete_forever),
+                        onPressed: () {
+                          // Permanently delete the email
+                          FirebaseFirestore.instance
+                              .collection('emails')
+                              .doc(email['id'])
+                              .delete();
+                        },
+                      ),
+                    ],
+                  ),
+                  onTap: () {
+                    // Navigate to the email detail screen
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => EmailDetailScreen(email: email),
+                      ),
+                    );
+                  },
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/services/email_service.dart
+++ b/lib/services/email_service.dart
@@ -10,6 +10,7 @@ class EmailService {
       'body': body,
       'timestamp': FieldValue.serverTimestamp(),
       'isRead': false,
+      'isTrashed': false,
       'labels': ['inbox'],
     });
   }


### PR DESCRIPTION
Adding trash screen and handle logics from moving email to trash, to choose an email in trash screen for permanently delete or recover it. Additionally, some of the screens' titles are synchronized with the app's title, as well as a field called: "isTrashed" is created to mark if that email is putted to trash.